### PR TITLE
Update base template for GUI Checkboxes

### DIFF
--- a/AtlasLootClassic/GUI/Template_CheckBox.lua
+++ b/AtlasLootClassic/GUI/Template_CheckBox.lua
@@ -43,7 +43,7 @@ function GUI.CreateCheckBox()
 	self.onClickFunc = nil	-- Run on OnClick
 	self.checked = false
 
-	self.frame = CreateFrame("CheckButton", frameName, nil, "OptionsCheckButtonTemplate")
+	self.frame = CreateFrame("CheckButton", frameName, nil, "UICheckButtonTemplate")
 	self.frame:SetWidth(25)
 	self.frame:SetHeight(25)
 	self.frame:SetScript("OnClick", OnClick)


### PR DESCRIPTION
Blizzard has changed the names of the component templates, and the Template_CheckBox in the GUI module stopped working. This prevents the Favourites module from working.

Updating the base template to `UICheckButtonTemplate` fixes the issue.